### PR TITLE
add hyperref usepackage

### DIFF
--- a/inst/extdata/templates/codecheck/codecheck-preamble.sty
+++ b/inst/extdata/templates/codecheck/codecheck-preamble.sty
@@ -2,6 +2,7 @@
 \usepackage{booktabs}
 \usepackage{rotating}
 \usepackage{makecell}
+\usepackage{hyperref}
 %% \usepackage[a4paper,margin=2cm]{geometry}
 
 


### PR DESCRIPTION
The `codecheck-preamble.sty` file makes use of the {hyperref} package:

`\hypersetup{colorlinks=true, urlcolor = [rgb]{0,.5,0.2}}`

But does not load it at the beginning, halting the knit. I had the same issue on two different Windows machines. Adding `\usepackage{hyperref}` at the top solved the problem.