### PR TITLE
Add codecheckers extra text

### DIFF
--- a/R/utils_render_table_non_registers.R
+++ b/R/utils_render_table_non_registers.R
@@ -173,7 +173,7 @@ generate_html_title_non_registers <- function(filter, subcat){
 generate_html_extra_text_non_register <- function(filter){
   extra_text <- ""
 
-  if (filter %in% CONFIG$NON_REG_EXTRA_TEXT){
+  if (filter %in% names(CONFIG$NON_REG_EXTRA_TEXT)){
     extra_text <- CONFIG$NON_REG_EXTRA_TEXT[[filter]]
   }
 

--- a/inst/extdata/config.R
+++ b/inst/extdata/config.R
@@ -98,7 +98,7 @@ CONFIG$NON_REG_TITLE_FNS <- list(
 
 CONFIG$NON_REG_EXTRA_TEXT <- list(
   codecheckers = "<i>\\*Note that the total number of codechecks is less than 
-    the collectisve sum of individual codecheckers' number of codechecks. 
+    the collective sum of individual codecheckers' number of codechecks. 
     This is because some codechecks involved more than one codechecker.</i>"
 )
 

--- a/inst/extdata/config.R
+++ b/inst/extdata/config.R
@@ -97,7 +97,7 @@ CONFIG$NON_REG_TITLE_FNS <- list(
 )
 
 CONFIG$NON_REG_EXTRA_TEXT <- list(
-  codecheckers = "<i>\\*Note that the total codechecks is less than 
+  codecheckers = "<i>\\*Note that the total number of codechecks is less than 
     the collectisve sum of individual codecheckers' number of codechecks. 
     This is because some codechecks involved more than one codechecker.</i>"
 )


### PR DESCRIPTION
As I redid a lot of the code, I made a mistake which resulted in the extra text in the codecheckers page not being added to the page. Fixed this error. 

Related register PR: https://github.com/codecheckers/register/pull/104

Merging without review as this is a minor change.