### PR TITLE
Using plural only for API resources

### DIFF
--- a/R/utils_render_register_general.r
+++ b/R/utils_render_register_general.r
@@ -185,7 +185,8 @@ generate_output_dir <- function(filter, table_details = list()) {
 
       # The table belongs to a subcat so we need a nested folder
       if ("subcat" %in% names(table_details)){
-        output_dir <- paste0(base_dir, filter, "/", table_details[["subcat"]], "/", table_name, "/")
+        plural_subcat <- CONFIG$VENUE_SUBCAT_PLURAL[[table_details[["subcat"]]]]
+        output_dir <- paste0(base_dir, filter, "/", plural_subcat, "/", table_name, "/")
       }
 
       # The table does not belong to a subcat

--- a/inst/extdata/config.R
+++ b/inst/extdata/config.R
@@ -72,6 +72,13 @@ CONFIG$HYPERLINKS <- list(
   zenodo_deposit = "https://zenodo.org/deposit/"
 )
 
+# Plural of venue subcategories 
+CONFIG$VENUE_SUBCAT_PLURAL <- list(
+  conference = "conferences",
+  journal = "journals",
+  community = "communities"
+)
+
 # NON-REGISTER_TABLE
 CONFIG$NON_REG_TITLE_BASE <- "CODECHECK List of"
 CONFIG$NON_REG_TITLE_FNS <- list(
@@ -124,11 +131,7 @@ CONFIG$NON_REG_SUBTEXT <- list(
 
       # Making the venue_name_subtext plural if necessary
       if (no_venues_subcat > 1){
-        venue_name_subtext <- switch (subcat,
-          "conference" = "conferences",
-          "journal" = "journals",
-          "community" = "communities"
-        )
+        venue_name_subtext <- CONFIG$VENUE_SUBCAT_PLURAL[[subcat]]
       }
       return(paste("In total,", total_codechecks, codecheck_word, "were completed for", no_venues_subcat, venue_name_subtext))
     }


### PR DESCRIPTION
Resolves issue: [#81](https://github.com/codecheckers/register/issues/81)

The venue subcategories are now pluralized for the API resources for consistency and in alignment with REST API convention. 

Example the link: https://codecheck.org.uk/register/venues/journal/
is now: https://codecheck.org.uk/register/venues/journals/