### PR TITLE
Fix venue type page hyperlinks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: codecheck
 Title: Helper Functions for CODECHECK Project
-Version: 0.10.0
+Version: 0.10.1
 Authors@R: 
     c(person(given = "Stephen",
             family = "Eglen",

--- a/R/utils_render_register_htmls.R
+++ b/R/utils_render_register_htmls.R
@@ -104,7 +104,12 @@ generate_href <- function(filter, table_details, href_type) {
 
   # Setting href for filters with subcategories
   if ("subcat" %in% names(table_details)){
-    return(paste0(base_url, filter, "/", table_details[["subcat"]], "/", table_details[["slug_name"]], "/register", href_details$ext))
+    subcat <- table_details[["subcat"]]
+    # If subcat is venue type, we pluralize the venue names
+    if (subcat %in% names(CONFIG$VENUE_SUBCAT_PLURAL)){
+      subcat <- CONFIG$VENUE_SUBCAT_PLURAL[[subcat]]
+    }
+    return(paste0(base_url, filter, "/", subcat, "/", table_details[["slug_name"]], "/register", href_details$ext))
   }
 
   # For filters without subcategories

--- a/R/utils_render_table_non_registers.R
+++ b/R/utils_render_table_non_registers.R
@@ -86,6 +86,10 @@ generate_html_postfix_hrefs_non_reg <- function(filter, table_details){
   # Case we do not have subcat
   if ("subcat" %in% names(table_details)){
     subcat <- table_details[["subcat"]]
+    # If subcat is venue type, we pluralize the venue names
+    if (subcat %in% names(CONFIG$VENUE_SUBCAT_PLURAL)){
+      subcat <- CONFIG$VENUE_SUBCAT_PLURAL[[subcat]]
+    }
     hrefs <- list(
       json_href = paste0(CONFIG$HYPERLINKS[["register"]], filter, "/", subcat,"/index.json")
     )


### PR DESCRIPTION
Related codecheck repo PR: https://github.com/codecheckers/register/pull/118

Fixed a bug in the venue type pages- the hyperlinks in the postfix still contained singular form of the venue types which should have been fixed in this PR https://github.com/codecheckers/register/pull/112. 

For instance an example of the fualty hyperlink is:
`https://codecheck.org.uk/register/venues/community/index.json`
when it should be
`https://codecheck.org.uk/register/venues/communities/index.json`