### PR TITLE
Bug- fix cert pages with no cert preview

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: codecheck
 Title: Helper Functions for CODECHECK Project
-Version: 0.11.0
+Version: 0.11.1
 Authors@R: 
     c(person(given = "Stephen",
             family = "Eglen",

--- a/R/utils_render_cert_htmls.R
+++ b/R/utils_render_cert_htmls.R
@@ -43,6 +43,11 @@ render_cert_htmls <- function(register_table, force_download = FALSE){
       Sys.sleep(CONFIG$CERT_REQUEST_DELAY)
     }
 
+    # The pdf exists and force download is False
+    else{
+      download_cert_status <- 1
+    }
+
     render_cert_html(cert_id, register_table[i, ]$Repository, download_cert_status)
   }
 }

--- a/R/utils_render_cert_htmls.R
+++ b/R/utils_render_cert_htmls.R
@@ -43,7 +43,7 @@ render_cert_htmls <- function(register_table, force_download = FALSE){
       Sys.sleep(CONFIG$CERT_REQUEST_DELAY)
     }
 
-    render_cert_html(cert_id, register_table[i, ]$Repository, download_cert_status=1)
+    render_cert_html(cert_id, register_table[i, ]$Repository, download_cert_status)
   }
 }
 

--- a/R/utils_render_cert_md.R
+++ b/R/utils_render_cert_md.R
@@ -218,6 +218,7 @@ create_cert_md <- function(cert_id, repo_link, download_cert_status){
 
   # We add the report link in the subtext when we do not have cert
   if (download_cert_status == 0){
+    config_yml <- get_codecheck_yml(repo_link)
     report_hyperlink <- paste0("[link](", config_yml$report, ")")
     md_content <- gsub("\\$codecheck_report_subtext\\$", report_hyperlink, md_content)
   }

--- a/R/utils_render_cert_md.R
+++ b/R/utils_render_cert_md.R
@@ -201,7 +201,7 @@ add_abstract <- function(repo_link, md_content){
 create_cert_md <- function(cert_id, repo_link, download_cert_status){
   cert_dir <- file.path(CONFIG$CERTS_DIR[["cert"]], cert_id)
   
-  # Initially checking if a cert is available
+  # Loading the correct template based on whether cert exists
   if (download_cert_status == 0) {
     template_type <- "md_template_no_cert"
   }


### PR DESCRIPTION
Fixed a bug in the "cert page" feature: [link to feature PR](https://github.com/codecheckers/codecheck/pull/71)

The `render_cert_html` had `cert_download_status = 1` passed as default. As a result papers with no certs had the wrong cert page layout. The issue was fixed in this PR