### PR TITLE
Fix codechecker hyperlink when no orcid id is there

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: codecheck
 Title: Helper Functions for CODECHECK Project
-Version: 0.11.1
+Version: 0.11.2
 Authors@R: 
     c(person(given = "Stephen",
             family = "Eglen",

--- a/R/utils_render_cert_htmls.R
+++ b/R/utils_render_cert_htmls.R
@@ -5,10 +5,6 @@
 #' @param register_table A data frame containing details of each certificate, including repository links and report links.
 #' @param force_download Logical; if TRUE, forces the download of certificate PDFs even if they already exist locally. Defaults to FALSE.
 render_cert_htmls <- function(register_table, force_download = FALSE){
-  # Keeping a list of failed cert pages. No hyperlinks will be added for these certs
-  CONFIG$LIST_FAILED_CERT_PAGES <- list()
-  CONFIG$LIST_FAILED_ABSTRACT <- list()
-
   # Read template
   html_template <- readLines(CONFIG$CERTS_DIR[["cert_page_template"]])
 
@@ -34,11 +30,6 @@ render_cert_htmls <- function(register_table, force_download = FALSE){
         convert_cert_pdf_to_jpeg(cert_id)
       }
 
-      # Failed in downloading cert
-      else{
-        CONFIG$LIST_FAILED_CERT_PAGES <- append(CONFIG$LIST_FAILED_CERT_PAGES, cert_id)
-        Sys.sleep(CONFIG$CERT_REQUEST_DELAY)
-      }
       # Delaying reqwuests to adhere to request limits
       Sys.sleep(CONFIG$CERT_REQUEST_DELAY)
     }

--- a/R/utils_render_cert_md.R
+++ b/R/utils_render_cert_md.R
@@ -301,8 +301,8 @@ add_codecheck_details_md <- function(md_content, repo_link){
 
   # Adding the Codechecker name
   codechecker_names <- c()
-  for (checker in config_yml$codecheck){
 
+  for (checker in config_yml$codechecker){
     # Creating a hyperlink if the ORCID ID is available
     if ("ORCID" %in% names(checker)){
       codechecker <- paste0("[", checker$name, "](", CONFIG$HYPERLINKS["orcid"], checker$ORCID, ")")
@@ -313,6 +313,8 @@ add_codecheck_details_md <- function(md_content, repo_link){
     }
     codechecker_names <- append(codechecker_names, codechecker)
   }
+  # Concatenate all entries into a single string separated by commas
+  codechecker_names <- paste(codechecker_names, collapse = ", ")
 
   # Adjusting the codechecker name heading 
   # Multiple codecheckers

--- a/R/utils_render_cert_md.R
+++ b/R/utils_render_cert_md.R
@@ -300,10 +300,19 @@ add_codecheck_details_md <- function(md_content, repo_link){
   config_yml <- get_codecheck_yml(repo_link)
 
   # Adding the Codechecker name
-  codechecker_names <- paste(lapply(config_yml$codechecker, function(checker) {
-    paste0("[", checker$name, "](", 
-    CONFIG$HYPERLINKS["orcid"], checker$ORCID, ")")
-    }), collapse = ", ")
+  codechecker_names <- c()
+  for (checker in config_yml$codecheck){
+
+    # Creating a hyperlink if the ORCID ID is available
+    if ("ORCID" %in% names(checker)){
+      codechecker <- paste0("[", checker$name, "](", CONFIG$HYPERLINKS["orcid"], checker$ORCID, ")")
+    }
+
+    else{
+      codechecker <- checker$name
+    }
+    codechecker_names <- append(codechecker_names, codechecker)
+  }
 
   # Adjusting the codechecker name heading 
   # Multiple codecheckers


### PR DESCRIPTION
Related register repo PR: [link](https://github.com/codecheckers/register/pull/129)

In the cert pages- codechecker names with no associated orcid IDs should not have a hyperlink but it does. 
This issue is fixed in this PR in the function `add_codecheck_details_md`.

Additionally removed unused vars in `render_cert_htmls`.