### PR TITLE
Fix "NA" values in no.codechecks column in "List of codecheckers" page

### DIFF
--- a/R/utils_render_table_codecheckers.R
+++ b/R/utils_render_table_codecheckers.R
@@ -22,9 +22,13 @@ create_all_codecheckers_table <- function(register_table){
     mutate(`codechecker_name` = recode(Codechecker, !!!CONFIG$DICT_ORCID_ID_NAME))
 
   # Adding no. of codechecks column
+  # Count no. codechecks per Codechecker
+  codecheck_counts <- register_table %>%
+    count(Codechecker, name = "no_codechecks")
+
+  # Join no_codechecks column to new_table
   new_table <- new_table %>%
-    group_by(Codechecker) %>%
-    mutate(`no_codechecks` = sum(register_table$Codechecker == Codechecker))
+    left_join(codecheck_counts, by = "Codechecker")
 
   # Rename the column using the key-value pairs from the CONFIG list
   col_names_dict <- CONFIG$NON_REG_TABLE_COL_NAMES[["codecheckers"]]


### PR DESCRIPTION
Related register PR: https://github.com/codecheckers/register/pull/152

**The issue**
The no. codechecks column in "List of codecheckers" page was showing "NA" for all codecheckers.
This is a new issue because the register now has codecheckers without an ORCID ID. Since codecheckers are identified by ORCID ID's, these codecheckers are registered as NA.

The code would not work properly for all codecheckers when there is a single NA codechecker in the register

**The fix**
Changed the code to work normally for non-NA codecheckers  when there are NA codecheckers in the register